### PR TITLE
download promptless to ~

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ download() {
     url="https://raw.githubusercontent.com/dylanaraps/promptless"
     url="${url}/master/promptless.sh"
 
-    curl "$url" > promptless.sh || {
+    curl "$url" > ~/promptless.sh || {
         printf '%s\n' "error: Couldn't download promptless." >&2
         exit 1
     }
@@ -23,7 +23,7 @@ main() {
     download
     get_shell
 
-    printf '%s\n' ". '${PWD}/promptless.sh'" >> "$rc"
+    printf '%s\n' ". '~/promptless.sh'" >> "$rc"
     printf '%s\n' "Installation complete. Relaunch your shell."
 }
 


### PR DESCRIPTION
- [ ] Is your pull request webscale? // I'm sorry?

Anyway. This patch should cause the install script to download promptless into ~, instead of `$(pwd)`. 

The reason for this is that chances are that the user could be in some place like `/tmp/`, and if that was the case the script would be downloaded into that temporary directory and would be removed on reboot. Something similar actually happened to me.
